### PR TITLE
GW-77, GW-84, GW-90: TAF Validation bugs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<description>Aviation weather message conversions - GeoWeb module</description>
 	<groupId>com.github.KNMI</groupId>
 	<artifactId>geoweb-aviation-messageconverter</artifactId>
-	<version>1.53.0-SNAPSHOT</version>
+	<version>1.54.0-SNAPSHOT</version>
 	<scm>
 		<connection>${scm-url}</connection>
 		<developerConnection>${scm-url}</developerConnection>

--- a/src/main/java/nl/knmi/geoweb/backend/product/taf/augment/AugmentAscendingHeightClouds.java
+++ b/src/main/java/nl/knmi/geoweb/backend/product/taf/augment/AugmentAscendingHeightClouds.java
@@ -29,12 +29,18 @@ public class AugmentAscendingHeightClouds {
 				ObjectNode cloudNode = (ObjectNode) nextNode;				
 
 				JsonNode cloudHeight = cloudNode.findValue("height");
+				JsonNode cloudMod = cloudNode.findValue("mod");
 				if (cloudHeight == null || cloudHeight.asText().equals("null"))
 					continue;
-				int height = Integer.parseInt(cloudHeight.asText());
+				int height = Integer.parseInt(cloudHeight.asText());				
 				if (height <= prevHeight) {
-					cloudNode.put("cloudsHeightAscending", false);
-				}else{
+					if (cloudMod != null && cloudMod.asText().equals("CB") && height == prevHeight){
+						cloudNode.put("cloudsHeightAscending", true);	
+					}else {
+						cloudNode.put("cloudsHeightAscending", false);
+					}
+				}
+				else {
 					cloudNode.put("cloudsHeightAscending", true);
 				}
 				prevHeight = height;

--- a/src/main/java/nl/knmi/geoweb/backend/product/taf/augment/AugmentCloudNeededRainOrModifierNecessary.java
+++ b/src/main/java/nl/knmi/geoweb/backend/product/taf/augment/AugmentCloudNeededRainOrModifierNecessary.java
@@ -115,24 +115,6 @@ public class AugmentCloudNeededRainOrModifierNecessary {
 									|| cloud.get("mod").asText().equals("TCU"))));
 				}
 			}
-			if (forecastClouds != null && forecastClouds.isArray()) {
-				ArrayNode cloudsArray = (ArrayNode) forecastClouds;
-				boolean modifierPresent = StreamSupport.stream(cloudsArray.spliterator(), true)
-						.anyMatch(cloud -> cloud.has("mod")
-								&& (cloud.get("mod").asText().equals("CB") || cloud.get("mod").asText().equals("TCU")));
-				if (modifierPresent) {
-					forecast.put("cloudsModifierHasWeatherPresent", rainOrThunderstormPresent);
-				}
-			}
-
-		} else {
-			if (forecastClouds != null && forecastClouds.isArray()) {
-				ArrayNode cloudsArray = (ArrayNode) forecastClouds;
-				boolean modifierPresent = StreamSupport.stream(cloudsArray.spliterator(), true)
-						.anyMatch(cloud -> cloud.has("mod")
-								&& (cloud.get("mod").asText().equals("CB") || cloud.get("mod").asText().equals("TCU")));
-				forecast.put("cloudsModifierHasWeatherPresent", !modifierPresent);
-			}
 		}
 	}
 }

--- a/src/main/java/nl/knmi/geoweb/backend/product/taf/augment/AugmentMaxVerticalVisibility.java
+++ b/src/main/java/nl/knmi/geoweb/backend/product/taf/augment/AugmentMaxVerticalVisibility.java
@@ -10,6 +10,10 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import nl.knmi.geoweb.backend.product.taf.TafValidator;
 
+// FIXME: [entire project] the check .isMissing() applies only to .path() calls. 
+// In the code is used also for the .get(), .findParents(), ect calls.
+// It should be removed when it is not necessary.
+
 public class AugmentMaxVerticalVisibility {
 
 

--- a/src/main/resources/EnrichedTafValidatorSchema.json
+++ b/src/main/resources/EnrichedTafValidatorSchema.json
@@ -346,6 +346,15 @@
                     ],
                     "type": "boolean"
                 },
+                "verticalVisibilityOnlyWithCloudsCBorTCU": {
+                    "$geoweb::messages": {
+                        "enum": "In the presence of VV only CB or TCU clouds are allowed"
+                    },
+                    "enum": [
+                        true
+                    ],
+                    "type": "boolean"
+                },
                 "wind": {
                     "properties": {
                         "gustFastEnough": {

--- a/src/main/resources/EnrichedTafValidatorSchema.json
+++ b/src/main/resources/EnrichedTafValidatorSchema.json
@@ -283,15 +283,6 @@
                     ],
                     "type": "boolean"
                 },
-                "cloudsModifierHasWeatherPresent": {
-                    "$geoweb::messages": {
-                        "enum": "In the presence of CB or TCU a weather group with SH or TS is required"
-                    },
-                    "enum": [
-                        true
-                    ],
-                    "type": "boolean"
-                },
                 "cloudsNeededAndPresent": {
                     "$geoweb::messages": {
                         "enum": "Clouds are necessary for rain"

--- a/src/test/java/nl/knmi/geoweb/backend/product/taf/TafValidatorTest.java
+++ b/src/test/java/nl/knmi/geoweb/backend/product/taf/TafValidatorTest.java
@@ -67,7 +67,6 @@ public class TafValidatorTest {
 		assertThat(report.getErrors().toString(), is("{\"/changegroups/0/forecast/wind/windEnoughDifference\":"
 				+ "[\"Change in wind must be at least 30 degrees or 5 knots\"]}"));
 		assertThat(report.isSucceeded(), is(false));
-
 	}
 
 	/* Tests speedOperator and gustsOperator */
@@ -79,7 +78,6 @@ public class TafValidatorTest {
 		TafValidator tafValidator = new TafValidator(tafSchemaStore, tafObjectMapper);
 		TafValidationResult report = tafValidator.validate(tafString);
 		assertThat(report.isSucceeded(), is(true));
-
 	}
 
 	/*
@@ -94,7 +92,6 @@ public class TafValidatorTest {
 		TafValidator tafValidator = new TafValidator(tafSchemaStore, tafObjectMapper);
 		TafValidationResult report = tafValidator.validate(tafString);
 		assertThat(report.isSucceeded(), is(true));
-
 	}
 
 	/* Tests validation should simply not crash on this one: One */
@@ -105,7 +102,6 @@ public class TafValidatorTest {
 		TafValidator tafValidator = new TafValidator(tafSchemaStore, tafObjectMapper);
 		TafValidationResult report = tafValidator.validate(tafString);
 		assertThat(report.isSucceeded(), is(false));
-
 	}
 
 	/* Tests validation should simply not crash on this one: Two */
@@ -116,7 +112,6 @@ public class TafValidatorTest {
 		TafValidator tafValidator = new TafValidator(tafSchemaStore, tafObjectMapper);
 		TafValidationResult report = tafValidator.validate(tafString);
 		assertThat(report.isSucceeded(), is(true));
-
 	}
 
 	/* Clouds NOT ascending in height should give valid pointer */
@@ -130,7 +125,16 @@ public class TafValidatorTest {
 		assertThat(report.getErrors().toString(),
 				is("{\"/forecast/clouds/1/cloudsHeightAscending\":[\"Cloud groups must be ascending in height\"]}"));
 		assertThat(report.isSucceeded(), is(false));
+	}
 
+	/* Clouds with the same height if CB should give valid pointer */
+	@Test
+	public void testValidate_test_taf_clouds_with_same_height_if_CB_should_give_valid_pointer() throws Exception {
+		String tafString = "{\"forecast\":{\"clouds\":[{\"amount\":\"OVC\",\"height\":15},{\"amount\":\"OVC\",\"height\":15,\"mod\":\"CB\"}],\"visibility\":{\"unit\":\"M\",\"value\":6000},\"weather\":[{\"qualifier\":\"moderate\",\"descriptor\":\"showers\",\"phenomena\":[\"rain\"]}],\"wind\":{\"direction\":200,\"speed\":20,\"unit\":\"KT\"}},\"metadata\":{\"location\":\"EHAM\",\"validityStart\":\"2018-06-18T12:00:00Z\",\"validityEnd\":\"2018-06-19T18:00:00Z\"},\"changegroups\":[{\"changeStart\":\"2018-06-18T14:00:00Z\",\"changeEnd\":\"2018-06-18T16:00:00Z\",\"changeType\":\"PROB30\",\"forecast\":{\"visibility\":{\"unit\":\"M\",\"value\":7000},\"wind\":{\"direction\":200,\"speed\":25,\"unit\":\"KT\"}}}]}";
+		TafSchemaStore tafSchemaStore = new TafSchemaStore(productstorelocation);
+		TafValidator tafValidator = new TafValidator(tafSchemaStore, tafObjectMapper);
+		TafValidationResult report = tafValidator.validate(tafString);
+		assertThat(report.isSucceeded(), is(true));
 	}
 
 	/* Clouds ascending in height should validate */
@@ -158,7 +162,6 @@ public class TafValidatorTest {
 		tafString = "{\"forecast\":{\"clouds\":[{\"amount\":\"OVC\",\"height\":20,\"mod\":\"CB\"}],\"visibility\":{\"unit\":\"M\",\"value\":2000},\"weather\":[{\"qualifier\":\"moderate\",\"descriptor\":\"freezing\",\"phenomena\":[\"fog\"]},{\"qualifier\":\"moderate\",\"descriptor\":\"showers\",\"phenomena\":[\"rain\"]}],\"wind\":{\"direction\":200,\"speed\":20,\"unit\":\"KT\"}},\"metadata\":{\"location\":\"EHAM\",\"validityStart\":\"2018-06-18T12:00:00Z\",\"validityEnd\":\"2018-06-19T18:00:00Z\"},\"changegroups\":[]}";
 		report = tafValidator.validate(tafString);
 		assertThat(report.isSucceeded(), is(false));
-
 	}
 
 	/* Test metadata properties */
@@ -199,7 +202,6 @@ public class TafValidatorTest {
 		assertThat(report.getErrors().toString(), is(
 				"{\"/forecast/visibilityAndFogWithoutDescriptorWithinLimit\":[\"Fog requires a visibility of less than 1000 meters\"]}"));
 		assertThat(report.isSucceeded(), is(false));
-
 	}
 
 	/* Tests if heavy fog (+FG) gives proper feedback message */
@@ -213,6 +215,15 @@ public class TafValidatorTest {
 		assertThat(report.getErrors().toString(),
 				is("{\"/forecast/weather/0/qualifier\":[\"FG, BR, DU, HZ, SA, FU, VA, SQ, PO and TS can only be moderate\"]}"));
 		assertThat(report.isSucceeded(), is(false));
+	}
 
+	/* Tests with CB or TCU without weather group should validate */
+	@Test
+	public void testValidate_test_taf_changeGroup_without_weather_group_and_with_CB_or_TCU_should_validateOK() throws Exception {
+		String tafString = "{\"forecast\":{\"caVOK\":true,\"wind\":{\"direction\":120,\"speed\":40,\"unit\":\"KT\"}},\"metadata\":{\"location\":\"EHAM\",\"validityStart\":\"2018-06-18T12:00:00Z\",\"validityEnd\":\"2018-06-19T18:00:00Z\"},\"changegroups\":[{\"changeStart\":\"2018-06-18T14:00:00Z\",\"changeEnd\":\"2018-06-18T16:00:00Z\",\"changeType\":\"BECMG\",\"forecast\":{\"clouds\":[{\"amount\":\"BKN\",\"height\":4},{\"amount\":\"FEW\",\"height\":35,\"mod\":\"CB\"}]}}]}";
+		TafSchemaStore tafSchemaStore = new TafSchemaStore(productstorelocation);
+		TafValidator tafValidator = new TafValidator(tafSchemaStore, tafObjectMapper);
+		TafValidationResult report = tafValidator.validate(tafString);
+		assertThat(report.isSucceeded(), is(true));
 	}
 }

--- a/src/test/java/nl/knmi/geoweb/backend/product/taf/TafValidatorTest.java
+++ b/src/test/java/nl/knmi/geoweb/backend/product/taf/TafValidatorTest.java
@@ -22,6 +22,9 @@ import org.springframework.test.context.junit4.SpringRunner;
 import nl.knmi.adaguc.tools.Tools;
 import nl.knmi.geoweb.TestConfig;
 
+// FIXME: [entire file] TafSchemaStore and TafValidator are re-instantiated for each test. This is not desirable (performance, breaks dependency injection by Spring).
+// It needs to be refactored in a way that there will be only a single instance used multiple times.
+
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = { TestConfig.class })
 public class TafValidatorTest {


### PR DESCRIPTION
Solved TAF Validation bugs following the description in JIRA:
- GW-77: after a VV, now it is allowed to have only empty field, CB or TCU.
- GW-84: now CB or TCU doesn't need anymore to be associated to a weather group;
- GW-90: it is allowed now CB on the same height;
Version bumped to 1.54.0
