### PR TITLE
GW-141, GW-83: TAF Validation wind-group

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<description>Aviation weather message conversions - GeoWeb module</description>
 	<groupId>com.github.KNMI</groupId>
 	<artifactId>geoweb-aviation-messageconverter</artifactId>
-	<version>1.54.0-SNAPSHOT</version>
+	<version>1.54.1-SNAPSHOT</version>
 	<scm>
 		<connection>${scm-url}</connection>
 		<developerConnection>${scm-url}</developerConnection>

--- a/src/main/java/nl/knmi/geoweb/backend/product/taf/augment/AugmentWindEnoughChange.java
+++ b/src/main/java/nl/knmi/geoweb/backend/product/taf/augment/AugmentWindEnoughChange.java
@@ -96,10 +96,9 @@ public class AugmentWindEnoughChange {
 				if (!changeGroupChangeAsText.equals("FM")) {
 					/* Wind speed difference should be more than 5 knots or 2 meters per second.*/	
 					int limitSpeedDifference = unit.equals("KT") ? 5 : 2;
-					if (gustDifference != 0) { 
-						wind.put("windEnoughDifference",
-								directionDifference >= 30 || speedDifference >= limitSpeedDifference);
-					}
+					int limitGustDifference = unit.equals("KT") ? 5 : 2;
+					wind.put("windEnoughDifference",
+							directionDifference >= 30 || speedDifference >= limitSpeedDifference || gustDifference >= limitGustDifference);
 				}
 				
 				/* Copy previous wind if change type is not PROB* or TEMPO */

--- a/src/main/resources/EnrichedTafValidatorSchema.json
+++ b/src/main/resources/EnrichedTafValidatorSchema.json
@@ -359,7 +359,7 @@
                         },
                         "windEnoughDifference": {
                             "$geoweb::messages": {
-                                "enum": "Change in wind must be at least 30 degrees or 5 knots"
+                                "enum": "Change in wind must be at least 30 degrees in direction or 5 knots (2 MPS) in speed or gust"
                             },
                             "enum": [
                                 true

--- a/src/test/java/nl/knmi/geoweb/backend/product/taf/TafValidatorTest.java
+++ b/src/test/java/nl/knmi/geoweb/backend/product/taf/TafValidatorTest.java
@@ -68,7 +68,7 @@ public class TafValidatorTest {
 		TafValidationResult report = tafValidator.validate(tafString);
 		System.out.println(report.getErrors());
 		assertThat(report.getErrors().toString(), is("{\"/changegroups/0/forecast/wind/windEnoughDifference\":"
-				+ "[\"Change in wind must be at least 30 degrees or 5 knots\"]}"));
+				+ "[\"Change in wind must be at least 30 degrees in direction or 5 knots (2 MPS) in speed or gust\"]}"));
 		assertThat(report.isSucceeded(), is(false));
 	}
 
@@ -141,7 +141,7 @@ public class TafValidatorTest {
 		TafValidationResult report = tafValidator.validate(tafString);
 		System.out.println(report.getErrors());
 		assertThat(report.getErrors().toString(), is("{\"/changegroups/0/forecast/wind/windEnoughDifference\":"
-				+ "[\"Change in wind must be at least 30 degrees or 5 knots\"]}"));
+				+ "[\"Change in wind must be at least 30 degrees in direction or 5 knots (2 MPS) in speed or gust\"]}"));
 		assertThat(report.isSucceeded(), is(false));
 	}
 
@@ -170,7 +170,7 @@ public class TafValidatorTest {
 		TafValidationResult report = tafValidator.validate(tafString);
 		System.out.println(report.getErrors());
 		assertThat(report.getErrors().toString(), is("{\"/changegroups/0/forecast/wind/windEnoughDifference\":"
-				+ "[\"Change in wind must be at least 30 degrees or 5 knots\"]}"));
+				+ "[\"Change in wind must be at least 30 degrees in direction or 5 knots (2 MPS) in speed or gust\"]}"));
 		assertThat(report.isSucceeded(), is(false));
 	}
 


### PR DESCRIPTION
Bumped to version 1.54.1
TAF validation for wind-group with/without gust.
Improved the feedback in case of TAF not validated if the rule of "at least a change of 30 deg (direction) and 5 kt (speed or gust)" between change-group is not respected.